### PR TITLE
Fix dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,40 @@
-lightning
-datasets
-webdataset
-lingpy
-librosa
-torchmetrics
-ipatok
-transformers
-webdataset
-sklearn
-sentencepiece
-tokenizers
-jsonargparse[signatures]
-torchvision
-torchaudio
-wandb
-soundfile 
-ninja
-torch
+# Core ML Frameworks (CUDA 12.2 compatible - use cu121 wheels)
+torch==2.1.2
+torchaudio==2.1.2
+torchvision==0.16.2
+torchmetrics==1.2.1
+lightning==2.1.3
+
+# Transformers & NLP
+transformers==4.37.2
+sentencepiece==0.1.99
+tokenizers==0.15.0
+
+# Audio Processing
+librosa==0.10.1
+soundfile==0.12.1
+
+# Data Processing
+webdataset==0.2.79
+datasets==2.16.1
+scikit-learn==1.3.2
+
+# Linguistics
+lingpy==2.6.13
+ipatok==0.3.0
+
+# Training & Experiment Tracking
+jsonargparse[signatures]==4.27.1
+wandb==0.16.2
+
+# Utilities
+numba==0.58.1
+numpy==1.24.4
+scipy==1.11.4
+ninja==1.11.1.1
+dtw-python==1.4.2
+tqdm==4.66.1
+matplotlib==3.8.2
+tslearn==0.6.3
+packaging==24.0
+setuptools==69.5.1


### PR DESCRIPTION

Updated `requirements.txt`
Pinned all dependency versions to ensure reproducibility
Fixed compatibility issues with CUDA 12.2 (PyTorch 2.1.2)
Resolved dependency conflicts:
       - `numpy==1.24.4` (compatible with numba, matplotlib, scikit-learn)
       - `numba==0.58.1` (compatible with numpy 1.24.x)
       - `lightning==2.1.3` (compatible with PyTorch 2.1.x)
       - `transformers==4.37.2`
       - Added missing dependencies: `tslearn`, `packaging`, `setuptools`
Tested on Python 3.10 with CUDA 12.2